### PR TITLE
Removed call to deprecated activationEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.3.2",
   "private": true,
   "description": "Will replace all old Ruby hash syntax with new",
-  "activationEvents": [
-    "ruby-syntax-replacer:replace"
-  ],
+  "activationCommands": {
+    "atom-text-editor": ["ruby-syntax-replacer:replace"]
+  },
   "repository": "https://github.com/omegahm/ruby-syntax-replacer",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
activationEvents is deprecated and will be removed in Atom 1.0. I have replaced this with activationCommands. This fixes issue #11.