### PR TITLE
Fix replace

### DIFF
--- a/lib/ruby-syntax-replacer.coffee
+++ b/lib/ruby-syntax-replacer.coffee
@@ -18,4 +18,4 @@ module.exports =
 
   _replaceHashRockets: (text) ->
     text.replace /([^:]|^):(\w+)\s?(\s*)=>\s?(\s*)/g, ($0, $1, $2, $3, $4) ->
-      "#{$1}#{$2}:#{$3}#{$4}"
+      "#{$1}#{$2}: #{$3}#{$4}"

--- a/spec/ruby-syntax-replacer-spec.coffee
+++ b/spec/ruby-syntax-replacer-spec.coffee
@@ -1,21 +1,20 @@
-{WorkspaceView} = require 'atom'
-
 describe "ruby-syntax-replacer", ->
   [activationPromise, editor, editorView] = []
 
   replaceSyntax = (callback) ->
-    editorView.trigger 'ruby-syntax-replacer:replace'
+    atom.commands.dispatch editorView, 'ruby-syntax-replacer:replace'
     waitsForPromise -> activationPromise
     runs(callback)
 
   beforeEach ->
-    atom.workspaceView = new WorkspaceView
-    atom.workspaceView.openSync()
+    waitsForPromise ->
+      atom.workspace.open()
 
-    editorView = atom.workspaceView.getActiveView()
-    editor = editorView.getEditor()
+    runs ->
+      editor = atom.workspace.getActiveTextEditor()
+      editorView = atom.views.getView(editor)
 
-    activationPromise = atom.packages.activatePackage('ruby-syntax-replacer')
+      activationPromise = atom.packages.activatePackage('ruby-syntax-replacer')
 
   describe "when the ruby-syntax-replacer:replace event is triggered", ->
     it "replaces all instances of old ruby syntax with new", ->


### PR DESCRIPTION
Hey Mads!

Thank you very much for your effort, I've been using this package for a while.

Since your last update, I've been having trouble because it didn't put a space after the `:` and so, `{ :foo => :bar }` is replaced with `foo::bar`.

I've fixed the spec, which didn't run and added the needed space into `_replaceHashRockets`.

Have a look please, and let me know!
